### PR TITLE
[Android] Add check before using client to solve NPE

### DIFF
--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -51,7 +51,7 @@ public class BackgroundGeolocationService extends Service {
   // service is terminated immediately.
   @Override
   public boolean onUnbind(Intent intent) {
-    if (client != null) {
+    if (client != null && locationCallback != null) {
       client.removeUpdates(locationCallback);
     }
     releaseMediaPlayer();

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -61,7 +61,7 @@ public class BackgroundGeolocationService extends Service {
 
   @Override
   public void onDestroy() {
-    if (client != null) {
+    if (client != null && locationCallback != null) {
       client.removeUpdates(locationCallback);
     }
     super.onDestroy();

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -51,7 +51,9 @@ public class BackgroundGeolocationService extends Service {
   // service is terminated immediately.
   @Override
   public boolean onUnbind(Intent intent) {
-    client.removeUpdates(locationCallback);
+    if (client != null) {
+      client.removeUpdates(locationCallback);
+    }
     releaseMediaPlayer();
     stopSelf();
     return false;
@@ -59,7 +61,9 @@ public class BackgroundGeolocationService extends Service {
 
   @Override
   public void onDestroy() {
-    client.removeUpdates(locationCallback);
+    if (client != null) {
+      client.removeUpdates(locationCallback);
+    }
     super.onDestroy();
     releaseMediaPlayer();
   }


### PR DESCRIPTION
It seems that according to the Google crash report this is causing a crash.
It make sense if somehow the service is destroyed before the client is initialized.
I'm not sure I know how this can happen, but since it does, it makes sense to guard the client usages in unbind and destroy methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of background geolocation on Android by adding safeguards during service unbind/destroy to avoid null-related crashes when location resources are unavailable. Users should experience fewer unexpected app closures and smoother shutdown of location tracking, especially in low-memory or system-reclaimed scenarios. No changes to functionality, settings, or public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->