### PR TITLE
[codex] make Android background geofence permission optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,13 @@ BackgroundGeolocation.setPlannedRoute({soundFile: "assets/myFile.mp3", route: [[
 
 ## Native geofencing
 
-Use native geofencing when you need lightweight location boundaries such as stores, job sites, delivery zones, campuses, or check-in areas. The plugin monitors geofences natively, emits JavaScript events while the app is active, and can send transition payloads directly to your backend while the WebView is suspended.
+Use native geofencing when you need lightweight location boundaries such as stores, job sites, delivery zones, campuses, or check-in areas. The plugin monitors geofences natively and emits JavaScript events while the app is active. Android background delivery is optional and only requested when you opt in.
 
 ```javascript
 import { BackgroundGeolocation } from "@capgo/background-geolocation";
 
-// Geofencing can notify JavaScript while the app is alive and can also POST
-// transitions natively while the WebView is suspended.
+// Geofencing can notify JavaScript while the app is alive.
 await BackgroundGeolocation.setupGeofencing({
-    url: "https://api.example.com/geofences",
     notifyOnEntry: true,
     notifyOnExit: true,
     payload: { userId: "123" }
@@ -129,13 +127,20 @@ handle.remove();
 
 ### Android background geofence permission
 
-The plugin does not add `ACCESS_BACKGROUND_LOCATION` by default. Add it to your app manifest only when you need background geofencing or background location updates:
+The plugin does not add `ACCESS_BACKGROUND_LOCATION` by default and does not request it unless you explicitly opt in. Apps that only use foreground location can omit this permission.
+
+Opt in only when you need Android geofence transitions while the app is in the background:
 
 ```xml
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
-Apps that only use foreground location can omit this permission.
+```javascript
+await BackgroundGeolocation.setupGeofencing({
+    url: "https://api.example.com/geofences",
+    backgroundLocation: true
+});
+```
 
 ```javascript
 // If you just want the current location, try something like this. The longer
@@ -211,7 +216,7 @@ Set the the `android.useLegacyBridge` option to `true` in your Capacitor configu
 
 On Android 13+, the app needs the `POST_NOTIFICATIONS` runtime permission to show the persistent notification informing the user that their location is being used in the background. This runtime permission is requested after the location permission is granted.
 
-For geofencing on Android 10+, the app also needs `ACCESS_BACKGROUND_LOCATION`. Android may require the user to grant this from system settings after foreground location is granted; use `openSettings()` if the permission remains denied.
+For background geofencing on Android 10+, the app also needs `ACCESS_BACKGROUND_LOCATION` and `backgroundLocation: true` in `setupGeofencing()`. Android may require the user to grant this from system settings after foreground location is granted; use `openSettings()` if the permission remains denied. Leave `backgroundLocation` unset or `false` if your app does not have Google Play approval for Android background location.
 
 If your app forwards location updates to a server in real time, be aware that after 5 minutes in the background Android will throttle HTTP requests initiated from the WebView. The solution is to use a native HTTP plugin such as [CapacitorHttp](https://capacitorjs.com/docs/apis/http). See https://github.com/capacitor-community/background-geolocation/issues/14.
 
@@ -359,8 +364,9 @@ setupGeofencing(options: GeofenceSetupOptions) => Promise<void>
 
 Configures native geofence transition handling.
 
-Call this before adding geofences when you need native background POSTs
-or default entry/exit settings.
+Call this before adding geofences when you need default entry/exit settings
+or native background POSTs. Android background POSTs require
+`backgroundLocation: true`.
 
 | Param         | Type                                                                  | Description                        |
 | ------------- | --------------------------------------------------------------------- | ---------------------------------- |
@@ -546,17 +552,18 @@ Extends the standard Error with optional error codes.
 
 Options for configuring native geofence transition handling.
 
-When `url` is provided, native iOS and Android code sends a JSON `POST`
-whenever a monitored region is entered or exited. This keeps geofence
-handling useful when the WebView is suspended.
+When `url` is provided, native code can send a JSON `POST` whenever a
+monitored region is entered or exited. Android background POST delivery
+requires `backgroundLocation: true`.
 
-| Prop                     | Type                                                             | Description                                                                                                                                                                                                                                              | Default           | Since  |
-| ------------------------ | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------ |
-| **`url`**                | <code>string</code>                                              | Endpoint that receives geofence transition payloads.                                                                                                                                                                                                     |                   | 8.0.30 |
-| **`notifyOnEntry`**      | <code>boolean</code>                                             | Whether entry transitions should be monitored.                                                                                                                                                                                                           | <code>true</code> | 8.0.30 |
-| **`notifyOnExit`**       | <code>boolean</code>                                             | Whether exit transitions should be monitored.                                                                                                                                                                                                            | <code>true</code> | 8.0.30 |
-| **`payload`**            | <code><a href="#record">Record</a>&lt;string, unknown&gt;</code> | Base JSON payload merged into every native transition POST and listener event.                                                                                                                                                                           |                   | 8.0.30 |
-| **`requestPermissions`** | <code>boolean</code>                                             | Whether the plugin should request the native location permission needed for geofencing. iOS geofencing needs Always location authorization. Android background geofencing needs foreground location and, on Android 10+, background location permission. | <code>true</code> | 8.0.30 |
+| Prop                     | Type                                                             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Default            | Since  |
+| ------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------ |
+| **`url`**                | <code>string</code>                                              | Endpoint that receives geofence transition payloads. On Android, native background POST delivery requires `backgroundLocation: true`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |                    | 8.0.30 |
+| **`notifyOnEntry`**      | <code>boolean</code>                                             | Whether entry transitions should be monitored.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | <code>true</code>  | 8.0.30 |
+| **`notifyOnExit`**       | <code>boolean</code>                                             | Whether exit transitions should be monitored.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | <code>true</code>  | 8.0.30 |
+| **`payload`**            | <code><a href="#record">Record</a>&lt;string, unknown&gt;</code> | Base JSON payload merged into every native transition POST and listener event.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |                    | 8.0.30 |
+| **`requestPermissions`** | <code>boolean</code>                                             | Whether the plugin should request the native location permission needed for geofencing. iOS geofencing needs Always location authorization. Android geofencing requests foreground location by default. Android background location is only requested when `backgroundLocation` is enabled.                                                                                                                                                                                                                                                                                                                                    | <code>true</code>  | 8.0.30 |
+| **`backgroundLocation`** | <code>boolean</code>                                             | Whether Android geofencing should opt into background location permission. The plugin does not add `ACCESS_BACKGROUND_LOCATION` to your app manifest. Leave this disabled if your app does not have Google Play approval for Android background location. Enable it only after adding `ACCESS_BACKGROUND_LOCATION` to your app manifest and when you need Android geofence transitions while the app is in the background. This option only affects Android. Android versions below 10 do not request an extra background-location runtime permission, but the option still gates native Android background geofence delivery. | <code>false</code> | 8.0.34 |
 
 
 #### AddGeofenceOptions

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -401,7 +401,7 @@ public class BackgroundGeolocation extends Plugin {
             geofencePermissionFuture = null;
             return;
         }
-        requestBackgroundLocationPermissionIfNeeded(call, call.getBoolean("backgroundLocation", false));
+        requestBackgroundLocationPermissionIfNeeded(call, GeofenceStore.getBackgroundLocation(getContext()));
     }
 
     @PermissionCallback

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -228,25 +228,34 @@ public class BackgroundGeolocation extends Plugin {
         }
 
         JSObject payload = call.getObject("payload", new JSObject());
-        GeofenceStore.saveSetup(getContext(), url, call.getBoolean("notifyOnEntry", true), call.getBoolean("notifyOnExit", true), payload);
+        boolean backgroundLocation = call.getBoolean("backgroundLocation", false);
+        GeofenceStore.saveSetup(
+            getContext(),
+            url,
+            call.getBoolean("notifyOnEntry", true),
+            call.getBoolean("notifyOnExit", true),
+            payload,
+            backgroundLocation
+        );
 
         if (!call.getBoolean("requestPermissions", true)) {
             call.resolve();
             return;
         }
 
-        requestGeofencePermissions(call)
+        requestGeofencePermissions(call, backgroundLocation)
             .thenRun(call::resolve)
             .exceptionally((throwable) -> {
-                call.reject("Background location permission is required for geofencing", "NOT_AUTHORIZED");
+                call.reject(geofencePermissionMessage(backgroundLocation), "NOT_AUTHORIZED");
                 return null;
             });
     }
 
     @PluginMethod
     public void addGeofence(PluginCall call) {
-        if (!hasGeofencePermissions()) {
-            call.reject("Background location permission is required for geofencing", "NOT_AUTHORIZED");
+        boolean backgroundLocation = GeofenceStore.getBackgroundLocation(getContext());
+        if (!hasGeofencePermissions(backgroundLocation)) {
+            call.reject(geofencePermissionMessage(backgroundLocation), "NOT_AUTHORIZED");
             return;
         }
         if (!isLocationEnabled(getContext())) {
@@ -322,7 +331,7 @@ public class BackgroundGeolocation extends Plugin {
                 })
                 .addOnFailureListener((exception) -> call.reject("Could not start monitoring the geofence", exception));
         } catch (SecurityException exception) {
-            call.reject("Background location permission is required for geofencing", "NOT_AUTHORIZED", exception);
+            call.reject(geofencePermissionMessage(backgroundLocation), "NOT_AUTHORIZED", exception);
         }
     }
 
@@ -365,8 +374,8 @@ public class BackgroundGeolocation extends Plugin {
         call.resolve(result);
     }
 
-    private CompletableFuture<Void> requestGeofencePermissions(PluginCall call) {
-        if (hasGeofencePermissions()) {
+    private CompletableFuture<Void> requestGeofencePermissions(PluginCall call, boolean backgroundLocation) {
+        if (hasGeofencePermissions(backgroundLocation)) {
             return CompletableFuture.completedFuture(null);
         }
         if (geofencePermissionFuture != null) {
@@ -378,7 +387,7 @@ public class BackgroundGeolocation extends Plugin {
             requestPermissionForAlias("location", call, "geofenceLocationPermissionsCallback");
             return future;
         }
-        requestBackgroundLocationPermissionIfNeeded(call);
+        requestBackgroundLocationPermissionIfNeeded(call, backgroundLocation);
         return future;
     }
 
@@ -392,7 +401,7 @@ public class BackgroundGeolocation extends Plugin {
             geofencePermissionFuture = null;
             return;
         }
-        requestBackgroundLocationPermissionIfNeeded(call);
+        requestBackgroundLocationPermissionIfNeeded(call, call.getBoolean("backgroundLocation", false));
     }
 
     @PermissionCallback
@@ -409,8 +418,8 @@ public class BackgroundGeolocation extends Plugin {
         geofencePermissionFuture = null;
     }
 
-    private void requestBackgroundLocationPermissionIfNeeded(PluginCall call) {
-        if (hasBackgroundLocationPermission()) {
+    private void requestBackgroundLocationPermissionIfNeeded(PluginCall call, boolean backgroundLocation) {
+        if (!backgroundLocation || hasBackgroundLocationPermission()) {
             geofencePermissionFuture.complete(null);
             geofencePermissionFuture = null;
             return;
@@ -418,8 +427,8 @@ public class BackgroundGeolocation extends Plugin {
         requestPermissionForAlias("backgroundLocation", call, "geofenceBackgroundPermissionsCallback");
     }
 
-    private boolean hasGeofencePermissions() {
-        return getPermissionState("location") == PermissionState.GRANTED && hasBackgroundLocationPermission();
+    private boolean hasGeofencePermissions(boolean backgroundLocation) {
+        return getPermissionState("location") == PermissionState.GRANTED && (!backgroundLocation || hasBackgroundLocationPermission());
     }
 
     private boolean hasBackgroundLocationPermission() {
@@ -430,6 +439,13 @@ public class BackgroundGeolocation extends Plugin {
             ContextCompat.checkSelfPermission(getContext(), Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
             PackageManager.PERMISSION_GRANTED
         );
+    }
+
+    private String geofencePermissionMessage(boolean backgroundLocation) {
+        if (backgroundLocation) {
+            return "Background location permission is required for geofencing";
+        }
+        return "Location permission is required for geofencing";
     }
 
     private GeofencingClient getGeofencingClient() {

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/GeofenceBootReceiver.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/GeofenceBootReceiver.java
@@ -34,6 +34,9 @@ public class GeofenceBootReceiver extends BroadcastReceiver {
 
     private static List<Task<Void>> restorePersistedGeofences(Context context) {
         List<Task<Void>> tasks = new ArrayList<>();
+        if (!GeofenceStore.getBackgroundLocation(context)) {
+            return tasks;
+        }
         var client = LocationServices.getGeofencingClient(context);
         for (String identifier : GeofenceStore.getRegionIds(context)) {
             JSONObject region = GeofenceStore.getRegion(context, identifier);

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/GeofenceStore.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/GeofenceStore.java
@@ -33,13 +33,21 @@ final class GeofenceStore {
     private static final String KEY_URL = "url";
     private static final String KEY_NOTIFY_ON_ENTRY = "notifyOnEntry";
     private static final String KEY_NOTIFY_ON_EXIT = "notifyOnExit";
+    private static final String KEY_BACKGROUND_LOCATION = "backgroundLocation";
     private static final String KEY_PAYLOAD = "payload";
     private static final String KEY_REGION_IDS = "regionIds";
     private static final String KEY_REGION_PREFIX = "region.";
 
     private GeofenceStore() {}
 
-    static void saveSetup(Context context, String url, boolean notifyOnEntry, boolean notifyOnExit, JSONObject payload) {
+    static void saveSetup(
+        Context context,
+        String url,
+        boolean notifyOnEntry,
+        boolean notifyOnExit,
+        JSONObject payload,
+        boolean backgroundLocation
+    ) {
         SharedPreferences.Editor editor = prefs(context).edit();
         if (url == null || url.isEmpty()) {
             editor.remove(KEY_URL);
@@ -48,6 +56,7 @@ final class GeofenceStore {
         }
         editor.putBoolean(KEY_NOTIFY_ON_ENTRY, notifyOnEntry);
         editor.putBoolean(KEY_NOTIFY_ON_EXIT, notifyOnExit);
+        editor.putBoolean(KEY_BACKGROUND_LOCATION, backgroundLocation);
         editor.putString(KEY_PAYLOAD, payload == null ? new JSONObject().toString() : payload.toString());
         editor.apply();
     }
@@ -62,6 +71,10 @@ final class GeofenceStore {
 
     static boolean getNotifyOnExit(Context context) {
         return prefs(context).getBoolean(KEY_NOTIFY_ON_EXIT, true);
+    }
+
+    static boolean getBackgroundLocation(Context context) {
+        return prefs(context).getBoolean(KEY_BACKGROUND_LOCATION, false);
     }
 
     static void saveRegion(
@@ -170,6 +183,9 @@ final class GeofenceStore {
     }
 
     static void enqueueTransition(Context context, JSONObject data) {
+        if (!getBackgroundLocation(context)) {
+            return;
+        }
         if (getUrl(context) == null || getUrl(context).isEmpty()) {
             return;
         }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -200,15 +200,17 @@ export interface SetPlannedRouteOptions {
 /**
  * Options for configuring native geofence transition handling.
  *
- * When `url` is provided, native iOS and Android code sends a JSON `POST`
- * whenever a monitored region is entered or exited. This keeps geofence
- * handling useful when the WebView is suspended.
+ * When `url` is provided, native code can send a JSON `POST` whenever a
+ * monitored region is entered or exited. Android background POST delivery
+ * requires `backgroundLocation: true`.
  *
  * @since 8.0.30
  */
 export interface GeofenceSetupOptions {
   /**
    * Endpoint that receives geofence transition payloads.
+   *
+   * On Android, native background POST delivery requires `backgroundLocation: true`.
    *
    * @since 8.0.30
    * @example "https://api.example.com/geofences"
@@ -244,14 +246,34 @@ export interface GeofenceSetupOptions {
   /**
    * Whether the plugin should request the native location permission needed for geofencing.
    *
-   * iOS geofencing needs Always location authorization. Android background geofencing
-   * needs foreground location and, on Android 10+, background location permission.
+   * iOS geofencing needs Always location authorization. Android geofencing requests
+   * foreground location by default. Android background location is only requested when
+   * `backgroundLocation` is enabled.
    *
    * @since 8.0.30
    * @default true
    * @example true
    */
   requestPermissions?: boolean;
+
+  /**
+   * Whether Android geofencing should opt into background location permission.
+   *
+   * The plugin does not add `ACCESS_BACKGROUND_LOCATION` to your app manifest.
+   * Leave this disabled if your app does not have Google Play approval for Android
+   * background location. Enable it only after adding `ACCESS_BACKGROUND_LOCATION`
+   * to your app manifest and when you need Android geofence transitions while the
+   * app is in the background.
+   *
+   * This option only affects Android. Android versions below 10 do not request
+   * an extra background-location runtime permission, but the option still gates
+   * native Android background geofence delivery.
+   *
+   * @since 8.0.34
+   * @default false
+   * @example false
+   */
+  backgroundLocation?: boolean;
 }
 
 /**
@@ -529,8 +551,9 @@ export interface BackgroundGeolocationPlugin {
   /**
    * Configures native geofence transition handling.
    *
-   * Call this before adding geofences when you need native background POSTs
-   * or default entry/exit settings.
+   * Call this before adding geofences when you need default entry/exit settings
+   * or native background POSTs. Android background POSTs require
+   * `backgroundLocation: true`.
    *
    * @param options The geofence configuration options
    * @returns A promise that resolves once geofencing is configured
@@ -538,7 +561,6 @@ export interface BackgroundGeolocationPlugin {
    * @since 8.0.30
    * @example
    * await BackgroundGeolocation.setupGeofencing({
-   *   url: "https://api.example.com/geofences",
    *   notifyOnEntry: true,
    *   notifyOnExit: true,
    *   payload: { userId: "123" }


### PR DESCRIPTION
## What
- Makes Android background geofence delivery opt-in with a new `backgroundLocation` setup option.
- Keeps Android geofencing on foreground location by default, without requesting `ACCESS_BACKGROUND_LOCATION`.
- Gates Android boot restore and native background transition POSTs behind the same opt-in flag.
- Updates the TypeScript API docs and README to explain when apps need to add `ACCESS_BACKGROUND_LOCATION` manually.

## Why
- `ACCESS_BACKGROUND_LOCATION` requires Google Play approval and should not be required for apps that only need foreground location/geofence behavior.
- This keeps the geofencing addition available for apps that need it while avoiding a forced permission surface for everyone else.

## How
- Persist the Android `backgroundLocation` setup choice in `GeofenceStore`.
- Request/check Android background location only when that flag is enabled.
- Skip Android boot restore and native background POST delivery unless the app opted in.
- Regenerate README API docs from `src/definitions.ts`.

## Testing
- `bun run fmt`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/martindonadieu/Library/Android/sdk" bun run verify`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/martindonadieu/Library/Android/sdk" bun run lint`
- `bun run verify:web`

## Not Tested
- Manual Android device flow for granting `ACCESS_BACKGROUND_LOCATION` from system settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `backgroundLocation` option to Android geofencing setup to opt into native background geofence transitions (default: off).

* **Bug Fixes**
  * Geofence background delivery, restoration, and transition scheduling are now blocked unless `backgroundLocation` is enabled.

* **Documentation**
  * Clarified Android background-location permission requirements, when to call setup, permission request behavior, and Google Play approval guidance for background geofencing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-background-geolocation/pull/35)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->