### PR TITLE
fix(android): handle ForegroundServiceStartNotAllowedException on start

### DIFF
--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -798,8 +798,10 @@ public class BackgroundGeolocation extends Plugin {
 
             @Override
             public void onServiceDisconnected(ComponentName name) {
-                serviceConnection = null;
-                serviceConnectionFuture = null;
+                if (serviceConnectionFuture == connectionFuture) {
+                    serviceConnection = null;
+                    serviceConnectionFuture = null;
+                }
             }
         };
         serviceConnection = connection;

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -58,6 +58,7 @@ public class BackgroundGeolocation extends Plugin {
     private final String pluginVersion = "";
 
     private CompletableFuture<BackgroundGeolocationService.LocalBinder> serviceConnectionFuture;
+    private ServiceConnection serviceConnection;
     private CompletableFuture<Void> locationPermissionFuture;
     private CompletableFuture<Void> geofencePermissionFuture;
     private BroadcastReceiver serviceReceiver;
@@ -115,7 +116,8 @@ public class BackgroundGeolocation extends Plugin {
         if (call.getBoolean("stale", false)) {
             fetchLastLocation(call);
         }
-        getServiceConnection()
+        CompletableFuture<BackgroundGeolocationService.LocalBinder> connectionFuture = getServiceConnection();
+        connectionFuture
             .thenAccept((serviceBinder) -> {
                 serviceBinder.start(
                     call.getCallbackId(),
@@ -128,7 +130,11 @@ public class BackgroundGeolocation extends Plugin {
                 );
             })
             .exceptionally((throwable) -> {
-                serviceConnectionFuture = null;
+                if (serviceConnectionFuture == connectionFuture) {
+                    releaseServiceConnection();
+                    stopBackgroundService();
+                    serviceConnectionFuture = null;
+                }
                 rejectServiceStartFailure(call, throwable);
                 return null;
             });
@@ -771,7 +777,7 @@ public class BackgroundGeolocation extends Plugin {
         CompletableFuture<BackgroundGeolocationService.LocalBinder> connectionFuture = new CompletableFuture<>();
         serviceConnectionFuture = connectionFuture;
 
-        Intent serviceIntent = new Intent(this.getContext(), BackgroundGeolocationService.class);
+        Intent serviceIntent = createServiceIntent();
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 this.getContext().startForegroundService(serviceIntent);
@@ -784,33 +790,57 @@ public class BackgroundGeolocation extends Plugin {
             return connectionFuture;
         }
 
-        try {
-            boolean bound = this.getContext().bindService(
-                serviceIntent,
-                new ServiceConnection() {
-                    @Override
-                    public void onServiceConnected(ComponentName name, IBinder binder) {
-                        connectionFuture.complete((BackgroundGeolocationService.LocalBinder) binder);
-                    }
+        ServiceConnection connection = new ServiceConnection() {
+            @Override
+            public void onServiceConnected(ComponentName name, IBinder binder) {
+                connectionFuture.complete((BackgroundGeolocationService.LocalBinder) binder);
+            }
 
-                    @Override
-                    public void onServiceDisconnected(ComponentName name) {
-                        serviceConnectionFuture = null;
-                    }
-                },
-                Context.BIND_AUTO_CREATE
-            );
+            @Override
+            public void onServiceDisconnected(ComponentName name) {
+                serviceConnection = null;
+                serviceConnectionFuture = null;
+            }
+        };
+        serviceConnection = connection;
+
+        try {
+            boolean bound = this.getContext().bindService(serviceIntent, connection, Context.BIND_AUTO_CREATE);
             if (!bound) {
+                serviceConnection = null;
                 IllegalStateException exception = new IllegalStateException("Failed to bind to background location service");
                 connectionFuture.completeExceptionally(exception);
+                stopBackgroundService();
                 serviceConnectionFuture = null;
             }
         } catch (SecurityException exception) {
+            serviceConnection = null;
             connectionFuture.completeExceptionally(exception);
+            stopBackgroundService();
             serviceConnectionFuture = null;
         }
 
         return connectionFuture;
+    }
+
+    private Intent createServiceIntent() {
+        return new Intent(this.getContext(), BackgroundGeolocationService.class);
+    }
+
+    private void stopBackgroundService() {
+        getContext().stopService(createServiceIntent());
+    }
+
+    private void releaseServiceConnection() {
+        if (serviceConnection == null) {
+            return;
+        }
+        try {
+            getContext().unbindService(serviceConnection);
+        } catch (IllegalArgumentException ignored) {
+            // Service was not bound or already unbound.
+        }
+        serviceConnection = null;
     }
 
     private void rejectServiceStartFailure(PluginCall call, Throwable throwable) {

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -128,6 +128,7 @@ public class BackgroundGeolocation extends Plugin {
                 );
             })
             .exceptionally((throwable) -> {
+                serviceConnectionFuture = null;
                 rejectServiceStartFailure(call, throwable);
                 return null;
             });
@@ -783,21 +784,31 @@ public class BackgroundGeolocation extends Plugin {
             return connectionFuture;
         }
 
-        this.getContext().bindService(
-            serviceIntent,
-            new ServiceConnection() {
-                @Override
-                public void onServiceConnected(ComponentName name, IBinder binder) {
-                    connectionFuture.complete((BackgroundGeolocationService.LocalBinder) binder);
-                }
+        try {
+            boolean bound = this.getContext().bindService(
+                serviceIntent,
+                new ServiceConnection() {
+                    @Override
+                    public void onServiceConnected(ComponentName name, IBinder binder) {
+                        connectionFuture.complete((BackgroundGeolocationService.LocalBinder) binder);
+                    }
 
-                @Override
-                public void onServiceDisconnected(ComponentName name) {
-                    serviceConnectionFuture = null;
-                }
-            },
-            Context.BIND_AUTO_CREATE
-        );
+                    @Override
+                    public void onServiceDisconnected(ComponentName name) {
+                        serviceConnectionFuture = null;
+                    }
+                },
+                Context.BIND_AUTO_CREATE
+            );
+            if (!bound) {
+                IllegalStateException exception = new IllegalStateException("Failed to bind to background location service");
+                connectionFuture.completeExceptionally(exception);
+                serviceConnectionFuture = null;
+            }
+        } catch (SecurityException exception) {
+            connectionFuture.completeExceptionally(exception);
+            serviceConnectionFuture = null;
+        }
 
         return connectionFuture;
     }

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -808,11 +808,18 @@ public class BackgroundGeolocation extends Plugin {
             call.reject(
                 "Cannot start background location while the app is in the background. Bring the app to the foreground and call start() again.",
                 "FOREGROUND_SERVICE_START_NOT_ALLOWED",
-                cause
+                toException(cause)
             );
             return;
         }
-        call.reject("Failed to start background location service: " + cause.getMessage(), cause);
+        call.reject("Failed to start background location service: " + cause.getMessage(), toException(cause));
+    }
+
+    private static Exception toException(Throwable throwable) {
+        if (throwable instanceof Exception) {
+            return (Exception) throwable;
+        }
+        return new Exception(throwable);
     }
 
     static boolean isForegroundServiceStartNotAllowed(Throwable throwable) {

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -1,6 +1,7 @@
 package com.capgo.capacitor_background_geolocation;
 
 import android.Manifest;
+import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
@@ -114,17 +115,22 @@ public class BackgroundGeolocation extends Plugin {
         if (call.getBoolean("stale", false)) {
             fetchLastLocation(call);
         }
-        getServiceConnection().thenAccept((serviceBinder) -> {
-            serviceBinder.start(
-                call.getCallbackId(),
-                call.getString("backgroundTitle", "Using your location"),
-                call.getString("backgroundMessage", ""),
-                call.getFloat("distanceFilter", 0f),
-                call.getString("url", null),
-                headersFromCall(call),
-                call.getLong("minIntervalMs", 0L)
-            );
-        });
+        getServiceConnection()
+            .thenAccept((serviceBinder) -> {
+                serviceBinder.start(
+                    call.getCallbackId(),
+                    call.getString("backgroundTitle", "Using your location"),
+                    call.getString("backgroundMessage", ""),
+                    call.getFloat("distanceFilter", 0f),
+                    call.getString("url", null),
+                    headersFromCall(call),
+                    call.getLong("minIntervalMs", 0L)
+                );
+            })
+            .exceptionally((throwable) -> {
+                rejectServiceStartFailure(call, throwable);
+                return null;
+            });
     }
 
     @PluginMethod
@@ -761,13 +767,20 @@ public class BackgroundGeolocation extends Plugin {
             return serviceConnectionFuture;
         }
 
-        serviceConnectionFuture = new CompletableFuture<>();
+        CompletableFuture<BackgroundGeolocationService.LocalBinder> connectionFuture = new CompletableFuture<>();
+        serviceConnectionFuture = connectionFuture;
 
         Intent serviceIntent = new Intent(this.getContext(), BackgroundGeolocationService.class);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            this.getContext().startForegroundService(serviceIntent);
-        } else {
-            this.getContext().startService(serviceIntent);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                this.getContext().startForegroundService(serviceIntent);
+            } else {
+                this.getContext().startService(serviceIntent);
+            }
+        } catch (RuntimeException exception) {
+            connectionFuture.completeExceptionally(exception);
+            serviceConnectionFuture = null;
+            return connectionFuture;
         }
 
         this.getContext().bindService(
@@ -775,7 +788,7 @@ public class BackgroundGeolocation extends Plugin {
             new ServiceConnection() {
                 @Override
                 public void onServiceConnected(ComponentName name, IBinder binder) {
-                    serviceConnectionFuture.complete((BackgroundGeolocationService.LocalBinder) binder);
+                    connectionFuture.complete((BackgroundGeolocationService.LocalBinder) binder);
                 }
 
                 @Override
@@ -786,7 +799,41 @@ public class BackgroundGeolocation extends Plugin {
             Context.BIND_AUTO_CREATE
         );
 
-        return serviceConnectionFuture;
+        return connectionFuture;
+    }
+
+    private void rejectServiceStartFailure(PluginCall call, Throwable throwable) {
+        Throwable cause = unwrapThrowable(throwable);
+        if (isForegroundServiceStartNotAllowed(cause)) {
+            call.reject(
+                "Cannot start background location while the app is in the background. Bring the app to the foreground and call start() again.",
+                "FOREGROUND_SERVICE_START_NOT_ALLOWED",
+                cause
+            );
+            return;
+        }
+        call.reject("Failed to start background location service: " + cause.getMessage(), cause);
+    }
+
+    static boolean isForegroundServiceStartNotAllowed(Throwable throwable) {
+        while (throwable != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && throwable instanceof ForegroundServiceStartNotAllowedException) {
+                return true;
+            }
+            String className = throwable.getClass().getName();
+            if (className.endsWith("ForegroundServiceStartNotAllowedException") || className.endsWith("ServiceStartNotAllowedException")) {
+                return true;
+            }
+            throwable = throwable.getCause();
+        }
+        return false;
+    }
+
+    private static Throwable unwrapThrowable(Throwable throwable) {
+        if (throwable instanceof java.util.concurrent.CompletionException && throwable.getCause() != null) {
+            return throwable.getCause();
+        }
+        return throwable;
     }
 
     @Override

--- a/android/src/test/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationUnitTest.java
+++ b/android/src/test/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationUnitTest.java
@@ -108,6 +108,28 @@ public class BackgroundGeolocationUnitTest {
     }
 
     @Test
+    public void testForegroundServiceStartNotAllowedDetection() {
+        assertTrue(
+            "ForegroundServiceStartNotAllowedException class name should be detected",
+            BackgroundGeolocation.isForegroundServiceStartNotAllowed(new ForegroundServiceStartNotAllowedException())
+        );
+        assertTrue(
+            "ServiceStartNotAllowedException class name should be detected",
+            BackgroundGeolocation.isForegroundServiceStartNotAllowed(new ServiceStartNotAllowedException())
+        );
+        assertTrue(
+            "Wrapped foreground service start failures should be detected",
+            BackgroundGeolocation.isForegroundServiceStartNotAllowed(
+                new RuntimeException("wrapped", new ForegroundServiceStartNotAllowedException())
+            )
+        );
+        assertFalse(
+            "Unrelated exceptions should not be treated as FGS start failures",
+            BackgroundGeolocation.isForegroundServiceStartNotAllowed(new IllegalStateException("other failure"))
+        );
+    }
+
+    @Test
     public void testBasicArithmetic() {
         // Basic sanity test
         assertEquals(4, 2 + 2);
@@ -189,4 +211,8 @@ public class BackgroundGeolocationUnitTest {
         throws NoSuchMethodException {
         assertEquals(listener.getClass(), listener.getClass().getDeclaredMethod(methodName, parameterTypes).getDeclaringClass());
     }
+
+    private static class ForegroundServiceStartNotAllowedException extends RuntimeException {}
+
+    private static class ServiceStartNotAllowedException extends RuntimeException {}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Catch `ForegroundServiceStartNotAllowedException` (and related `ServiceStartNotAllowedException` failures) when starting the Android foreground location service.
- Reject the `start()` plugin call with error code `FOREGROUND_SERVICE_START_NOT_ALLOWED` instead of crashing the app.
- Reset the service connection future on failed start so callers can retry after bringing the app to the foreground.

Fixes #58

## Why
On Android 12+, `Context.startForegroundService()` throws `ForegroundServiceStartNotAllowedException` when the app is in the background and the start is not in an allowed exemption. Play Console crash reports show this exception bubbling through Capacitor's bridge and terminating the app.

## How
- Wrapped `startForegroundService()` / `startService()` in `getServiceConnection()` with a `RuntimeException` catch.
- Added `rejectServiceStartFailure()` and `isForegroundServiceStartNotAllowed()` helpers to map the failure to a clear Capacitor plugin error.
- Added `.exceptionally()` handling in `proceedWithStart()` so the `start()` callback receives the rejection.
- Added unit tests for foreground-service start failure detection.

## Testing
- `bun run fmt`
- `bun run verify:web`
- Added `testForegroundServiceStartNotAllowedDetection` unit test

## Not Tested
- Full `bun run verify:android` locally (Android SDK unavailable in this cloud environment). CI should validate Android build/tests.
- Manual device reproduction of background `start()` on Android 12+ (expected: JS error, no crash).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1aabea74-28eb-4686-a12d-10f2b92e2dff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aabea74-28eb-4686-a12d-10f2b92e2dff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-background-geolocation/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789144690&installation_model_id=430928&pr_number=63&repository=Cap-go%2Fcapacitor-background-geolocation&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-background-geolocation%2Fpull%2F63&signature=4b0a853edc167e4c12bb2f89c7341162e31256269f11606cedce2905ae850fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-background-geolocation/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when Android prevents the background service from starting.
  * Reports a specific error when foreground-service startup is restricted.
  * Provides clearer error details for other service startup failures.
  * Ensures connection state is reset after unsuccessful startup attempts.

* **Tests**
  * Added coverage for direct and wrapped foreground-service restriction errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->