### PR TITLE
fix(android): read minIntervalMs with optLong for Integer bridge values

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:$androidxLocalbroadcastmanagerVersion"
     implementation "androidx.work:work-runtime:$androidxWorkRuntimeVersion"
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.json:json:20240303"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "com.google.android.gms:play-services-location:$playServicesLocationVersion"

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -126,7 +126,7 @@ public class BackgroundGeolocation extends Plugin {
                     call.getFloat("distanceFilter", 0f),
                     call.getString("url", null),
                     headersFromCall(call),
-                    call.getLong("minIntervalMs", 0L)
+                    longOptionFromCall(call, "minIntervalMs", 0L)
                 );
             })
             .exceptionally((throwable) -> {
@@ -649,6 +649,12 @@ public class BackgroundGeolocation extends Plugin {
                 Settings.Secure.LOCATION_MODE_OFF
             );
         }
+    }
+
+    // Capacitor's PluginCall.getLong() only reads Java Long values. JS numbers that
+    // fit in 32 bits cross the bridge as Integer, so optLong is required (issue #62).
+    static long longOptionFromCall(PluginCall call, String key, long defaultValue) {
+        return call.getData().optLong(key, defaultValue);
     }
 
     private static Map<String, String> headersFromCall(PluginCall call) {

--- a/android/src/test/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationUnitTest.java
+++ b/android/src/test/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationUnitTest.java
@@ -6,9 +6,12 @@ import android.content.Intent;
 import android.location.Location;
 import android.location.LocationListener;
 import android.os.Bundle;
+import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
+import com.getcapacitor.PluginCall;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofenceStatusCodes;
+import org.json.JSONException;
 import org.junit.Test;
 
 /**
@@ -105,6 +108,29 @@ public class BackgroundGeolocationUnitTest {
         );
         assertEquals(Geofence.GEOFENCE_TRANSITION_ENTER, GeofenceStore.geofenceTransitionTypes(true, false));
         assertEquals(Geofence.GEOFENCE_TRANSITION_EXIT, GeofenceStore.geofenceTransitionTypes(false, true));
+    }
+
+    @Test
+    public void testLongOptionFromCallCoercesIntegerBridgeValue() throws JSONException {
+        JSObject data = new JSObject();
+        data.put("minIntervalMs", 295_000);
+
+        PluginCall call = new PluginCall(null, "BackgroundGeolocation", "test-callback", "start", data);
+
+        assertEquals(
+            "JS numbers within Integer range must be read as minIntervalMs",
+            295_000L,
+            BackgroundGeolocation.longOptionFromCall(call, "minIntervalMs", 0L)
+        );
+        assertEquals("PluginCall.getLong misses Integer bridge values (issue #62)", Long.valueOf(0L), call.getLong("minIntervalMs", 0L));
+    }
+
+    @Test
+    public void testLongOptionFromCallUsesDefaultWhenMissing() {
+        PluginCall call = new PluginCall(null, "BackgroundGeolocation", "test-callback", "start", new JSObject());
+
+        assertEquals(0L, BackgroundGeolocation.longOptionFromCall(call, "minIntervalMs", 0L));
+        assertEquals(60_000L, BackgroundGeolocation.longOptionFromCall(call, "minIntervalMs", 60_000L));
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Read `minIntervalMs` on Android via `call.getData().optLong()` instead of `PluginCall.getLong()`.
- Add regression unit tests for the Integer bridge-value case.
- Add `org.json:json` as a test dependency so JVM unit tests can exercise real JSON coercion.

Fixes #62

## Why
- Typical JS numbers (e.g. `295_000`) cross the Capacitor bridge as `org.json` `Integer` values.
- Capacitor 8 `PluginCall.getLong()` only returns values that are already Java `Long` instances, so realistic `minIntervalMs` values were always read as `0`.
- With a configured URL, `LocationStore.shouldPost()` treated `minIntervalMs <= 0` as always-post, causing hundreds of POSTs instead of one every ~5 minutes.

## How
- Added `longOptionFromCall()` helper that uses `optLong()` (coerces Integer/Long/Double).
- Audited all `call.getLong(...)` usages in the plugin: `minIntervalMs` in `start()` was the only occurrence.
- iOS already uses `call.getDouble("minIntervalMs")` and is unaffected.

## Testing
- `./gradlew test` (Android unit tests), including new regression tests:
  - `testLongOptionFromCallCoercesIntegerBridgeValue` — verifies `295_000` Integer bridge value is read as `295_000L` and documents that `PluginCall.getLong()` returns the default.
  - `testLongOptionFromCallUsesDefaultWhenMissing` — verifies default handling when the option is absent.
- `bun run lint` and `bun run fmt`

## Not Tested
- On-device Android integration with a live URL endpoint (reporter's original repro scenario). The root cause and fix path are covered by unit tests and match Capacitor's `PluginCall.getLong()` implementation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d5bcfe-1194-40ff-aba4-9964848c22b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d5bcfe-1194-40ff-aba4-9964848c22b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-background-geolocation/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789215419&installation_model_id=430928&pr_number=64&repository=Cap-go%2Fcapacitor-background-geolocation&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-background-geolocation%2Fpull%2F64&signature=a455a5f127b92b884c762016dc56a82774eb283aa98ff71e8fcc985ed45aefdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-background-geolocation/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

