### PR TITLE
fix(android): fall back to NETWORK_PROVIDER when GPS goes silent in background

### DIFF
--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -123,7 +123,8 @@ public class BackgroundGeolocation extends Plugin {
                     call.getFloat("distanceFilter", 0f),
                     call.getString("url", null),
                     headersFromCall(call),
-                    longOptionFromCall(call, "minIntervalMs", 0L)
+                    longOptionFromCall(call, "minIntervalMs", 0L),
+                    call.getBoolean("networkFallback", false)
                 );
             })
             .exceptionally((throwable) -> {

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -139,6 +139,7 @@ public class BackgroundGeolocationService extends Service {
             currentMinIntervalMs = LocationStore.getMinIntervalMs(context);
             networkFallbackEnabled = LocationStore.getNetworkFallback(context);
             locationCallback = createLocationListener(this);
+            lastGpsFixAtMs = SystemClock.elapsedRealtime();
             requestLocationUpdates();
             startWatchdog();
         }
@@ -392,7 +393,7 @@ public class BackgroundGeolocationService extends Service {
             releaseMediaPlayer();
             acquireWakeLock();
             client = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
-            lastGpsFixAtMs = 0L;
+            lastGpsFixAtMs = SystemClock.elapsedRealtime();
             callbackId = id;
             currentDistanceFilter = distanceFilter;
             currentMinIntervalMs = Math.max(0L, minIntervalMs);

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -19,6 +19,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.PowerManager;
+import android.os.SystemClock;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.ServiceCompat;
 import androidx.core.location.LocationCompat;
@@ -57,6 +58,21 @@ public class BackgroundGeolocationService extends Service {
     private float currentDistanceFilter;
     private long currentMinIntervalMs;
     private PowerManager.WakeLock wakeLock;
+
+    // How long a GPS fix is considered "fresh" before we allow a NETWORK_PROVIDER fix through.
+    private static final long NETWORK_FALLBACK_GRACE_MS = 20000L;
+
+    // Max acceptable accuracy radius (meters) for a NETWORK_PROVIDER fix; missing accuracy counts
+    // as too imprecise too.
+    private static final float NETWORK_FIX_MAX_ACCURACY_M = 300f;
+
+    // elapsedRealtime() of the last GPS_PROVIDER fix, or 0 if none yet. Monotonic, so it can't be
+    // confused by wall-clock adjustments the way System.currentTimeMillis() could.
+    private volatile long lastGpsFixAtMs = 0L;
+
+    // Opt-in flag for the NETWORK_PROVIDER fallback below; set via the "networkFallback" start
+    // option. Defaults to off, so GPS-only accuracy is unchanged unless a caller asks for it.
+    private volatile boolean networkFallbackEnabled = false;
 
     // When set (via the "url" start option), each location is also POSTed to
     // this URL directly from native code so delivery survives the WebView being
@@ -121,6 +137,7 @@ public class BackgroundGeolocationService extends Service {
             client = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
             currentDistanceFilter = LocationStore.getDistanceFilter(context);
             currentMinIntervalMs = LocationStore.getMinIntervalMs(context);
+            networkFallbackEnabled = LocationStore.getNetworkFallback(context);
             locationCallback = createLocationListener(this);
             requestLocationUpdates();
             startWatchdog();
@@ -203,11 +220,7 @@ public class BackgroundGeolocationService extends Service {
             if (client == null || locationCallback == null) {
                 return;
             }
-            try {
-                client.requestLocationUpdates(LocationManager.GPS_PROVIDER, locationIntervalMs(), currentDistanceFilter, locationCallback);
-            } catch (SecurityException ignore) {
-                // Permission issues are handled in the start() method
-            }
+            requestLocationUpdates();
             startWatchdog();
         };
         watchdogHandler.postDelayed(restartRunnable, 10000);
@@ -231,6 +244,17 @@ public class BackgroundGeolocationService extends Service {
     }
 
     private void handleLocationChanged(android.location.Location location) {
+        if (LocationManager.GPS_PROVIDER.equals(location.getProvider())) {
+            lastGpsFixAtMs = SystemClock.elapsedRealtime();
+        } else if (LocationManager.NETWORK_PROVIDER.equals(location.getProvider())) {
+            boolean gpsStillFresh = lastGpsFixAtMs != 0 && (SystemClock.elapsedRealtime() - lastGpsFixAtMs) < NETWORK_FALLBACK_GRACE_MS;
+            boolean tooImprecise = !location.hasAccuracy() || location.getAccuracy() > NETWORK_FIX_MAX_ACCURACY_M;
+            if (gpsStillFresh || tooImprecise) {
+                // Drop it - and skip startWatchdog() below so a run of rejected fixes can't mask a
+                // genuinely stalled GPS_PROVIDER and suppress the restart that would recover it.
+                return;
+            }
+        }
         startWatchdog();
         if (nativePostUrl != null) {
             postLocationNatively(location);
@@ -305,6 +329,26 @@ public class BackgroundGeolocationService extends Service {
             // permissions are not yet granted. Rather than check the permissions, which is fiddly,
             // we simply ignore the exception.
         }
+        if (!networkFallbackEnabled) {
+            return;
+        }
+        // GPS_PROVIDER can go quiet for extended periods in the background or with poor sky
+        // visibility. Request NETWORK_PROVIDER on the same listener as a fallback; whichever
+        // fires first reaches handleLocationChanged(). No manifest change needed -
+        // ACCESS_COARSE_LOCATION is already declared. isProviderEnabled guards against devices
+        // with network location turned off.
+        try {
+            if (client.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
+                client.requestLocationUpdates(
+                    LocationManager.NETWORK_PROVIDER,
+                    locationIntervalMs(),
+                    currentDistanceFilter,
+                    locationCallback
+                );
+            }
+        } catch (SecurityException ignore) {
+            // Same rationale as the GPS_PROVIDER catch above.
+        }
     }
 
     // Promote the service to the foreground if necessary.
@@ -342,14 +386,17 @@ public class BackgroundGeolocationService extends Service {
             float distanceFilter,
             final String url,
             final Map<String, String> headers,
-            final long minIntervalMs
+            final long minIntervalMs,
+            final boolean networkFallback
         ) {
             releaseMediaPlayer();
             acquireWakeLock();
             client = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+            lastGpsFixAtMs = 0L;
             callbackId = id;
             currentDistanceFilter = distanceFilter;
             currentMinIntervalMs = Math.max(0L, minIntervalMs);
+            networkFallbackEnabled = networkFallback;
 
             nativePostUrl = (url == null || url.isEmpty()) ? null : url;
             LocationStore.saveSetup(
@@ -359,7 +406,8 @@ public class BackgroundGeolocationService extends Service {
                 notificationMessage,
                 distanceFilter,
                 headers,
-                currentMinIntervalMs
+                currentMinIntervalMs,
+                networkFallback
             );
 
             // The service may already be running (for example after a sticky

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocationService.java
@@ -418,6 +418,9 @@ public class BackgroundGeolocationService extends Service {
             }
             locationCallback = createLocationListener(BackgroundGeolocationService.this);
             requestLocationUpdates();
+            // Arm the watchdog here so rejected network fixes during the grace period cannot
+            // leave tracking without a restart path if GPS_PROVIDER goes silent.
+            startWatchdog();
             promoteToForeground(notificationTitle, notificationMessage);
         }
 

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/LocationStore.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/LocationStore.java
@@ -29,6 +29,7 @@ final class LocationStore {
     private static final String KEY_DISTANCE_FILTER = "distanceFilter";
     private static final String KEY_HEADERS = "headers";
     private static final String KEY_MIN_INTERVAL_MS = "minIntervalMs";
+    private static final String KEY_NETWORK_FALLBACK = "networkFallback";
     private static final String KEY_LAST_POST_TIME = "lastPostTime";
 
     private LocationStore() {}
@@ -45,7 +46,8 @@ final class LocationStore {
         String message,
         float distanceFilter,
         Map<String, String> headers,
-        long minIntervalMs
+        long minIntervalMs,
+        boolean networkFallback
     ) {
         SharedPreferences.Editor editor = prefs(context).edit();
         if (url == null || url.isEmpty()) {
@@ -59,6 +61,7 @@ final class LocationStore {
                 .putFloat(KEY_DISTANCE_FILTER, distanceFilter)
                 .putString(KEY_HEADERS, headersToJson(headers))
                 .putLong(KEY_MIN_INTERVAL_MS, Math.max(0L, minIntervalMs))
+                .putBoolean(KEY_NETWORK_FALLBACK, networkFallback)
                 .remove(KEY_LAST_POST_TIME);
         }
         editor.apply();
@@ -95,6 +98,10 @@ final class LocationStore {
 
     static long getMinIntervalMs(Context context) {
         return prefs(context).getLong(KEY_MIN_INTERVAL_MS, 0L);
+    }
+
+    static boolean getNetworkFallback(Context context) {
+        return prefs(context).getBoolean(KEY_NETWORK_FALLBACK, false);
     }
 
     static Map<String, String> getHeaders(Context context) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -188,6 +188,28 @@ export interface StartOptions {
    * @example 120000
    */
   minIntervalMs?: number;
+  /**
+   * Android only - has no effect on iOS. Whether to fall back to
+   * `NETWORK_PROVIDER` (cell/Wi-Fi based location) when `GPS_PROVIDER` has
+   * not delivered a fix recently. GPS can go quiet for extended periods when
+   * the app is backgrounded, the screen is locked, or the device has weak
+   * sky visibility (indoors, dense urban areas); the network fallback fills
+   * those gaps with a coarser, but far more reliably delivered, fix.
+   *
+   * GPS always takes priority: a network fix is only used once GPS has been
+   * silent for 20+ seconds, and is dropped if its reported accuracy is worse
+   * than 300m or unreported.
+   *
+   * Defaults to `false`, so existing GPS-only accuracy characteristics are
+   * unchanged unless you opt in.
+   *
+   * @since 8.5.0
+   * @default false
+   * @example
+   * // Fill gaps in GPS coverage with a coarser network-based location
+   * networkFallback: true
+   */
+  networkFallback?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
Continues AkShAy21211's work from #61 (network provider fallback when GPS goes silent) on a clean Cap-go branch.

#61's fork head picked up unintended `.github/workflows/*` reverts while integrating main (GitHub App `workflows` scope blocked a clean force-push to the fork). This PR is the same feature on `Cap-go:fix/network-provider-fallback` with **only** the 4 intended source files vs `main`.

Also includes the CodeRabbit fix: seed `lastGpsFixAtMs` before `requestLocationUpdates()` so the 20s grace applies before the first GPS fix.

## Credits
Original implementation: @AkShAy21211 in https://github.com/Cap-go/capacitor-background-geolocation/pull/61

## Test plan
- [ ] Android: with `networkFallback: true`, verify network fixes are rejected during the first 20s grace, then accepted after GPS silence
- [ ] Android: restore/start paths both seed grace and arm watchdog appropriately
- [ ] No `.github/workflows` diffs vs main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-background-geolocation/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791472241&installation_model_id=430928&pr_number=73&repository=Cap-go%2Fcapacitor-background-geolocation&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-background-geolocation%2Fpull%2F73&signature=38cbbae9375c5a60b07ea6d1856b96b2db73d4442d79f8066aaa292d54537f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-background-geolocation/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Android-only option to use cellular or Wi‑Fi location data when GPS has been unavailable for at least 20 seconds.
  * GPS remains the preferred source; inaccurate network fixes are filtered out.
  * The option is disabled by default, preserving existing GPS-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->